### PR TITLE
Changes seeker reticle to support WASD/Equivalent keybinds

### DIFF
--- a/FNF/FNFManager.cs
+++ b/FNF/FNFManager.cs
@@ -8,9 +8,11 @@ using GHPC;
 using GHPC.PhysicsHelpers;
 using GHPC.Player;
 using GHPC.AI;
+using GHPC.Crew;
 using GHPC.Utility;
-using MelonLoader;
 using System.Linq;
+using GHPC.Camera;
+using MelonLoader;
 
 namespace M2BradleyExtended.FNF
 {
@@ -24,6 +26,8 @@ namespace M2BradleyExtended.FNF
         private FireControlSystem fcs;
         private float seek_cd = 0f;
         private int self;
+        internal Vehicle own_vehicle;
+        private DriverBrain driver_brain;
 
         public AmmoType ammo_dir;
         public Vehicle target = null;
@@ -41,7 +45,9 @@ namespace M2BradleyExtended.FNF
 
         void Awake()
         {
-            self = GetComponentInParent<Vehicle>().GetInstanceID();
+            own_vehicle = GetComponentInParent<Vehicle>();
+            self = own_vehicle.GetInstanceID();
+            driver_brain = own_vehicle.GetComponentInChildren<DriverBrain>();
             weapon_system = GetComponent<WeaponSystem>();
             weapon_system_id = weapon_system.GetInstanceID();
             fcs = weapon_system.FCS;
@@ -244,6 +250,9 @@ namespace M2BradleyExtended.FNF
 
         public void SetSeeker(bool enabled)
         {
+            if (enabled)
+                own_vehicle.Chassis.KillDriving(true, false, false);
+
             seeker_active = enabled;
             SeekerToggled?.Invoke(seeker_active);
         }
@@ -251,6 +260,50 @@ namespace M2BradleyExtended.FNF
         public void SetTargetLocked(bool locked)
         {
             target_locked = locked;
+        }
+    }
+
+    [HarmonyPatch(typeof(CameraManager), "ToggleCameraSlotSet")]
+    internal class FNFCameraTogglePatch
+    {
+        private static void Postfix()
+        {
+            WeaponSystem weapon = PlayerInput.Instance?.CurrentPlayerWeapon?.Weapon;
+            if (weapon == null) return;
+
+            FNFManager fnf = weapon.GetComponent<FNFManager>();
+            if (fnf == null || !fnf.seeker_active) return;
+
+            if (!PlayerInput.Instance.IsExteriorMode)
+            {
+                fnf.own_vehicle.Chassis.KillDriving(true, false, false);
+            }
+            else
+            {
+                NwhChassis chassis = fnf.own_vehicle.Chassis as NwhChassis;
+                if (chassis != null)
+                {
+                    chassis.VehicleController.drivingAssists.cruiseControl.useBrakesOnOverspeed = false;
+                    chassis.VehicleController.drivingAssists.abs.enabled = true;
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(PlayerInput), "DriverInput")]
+    internal class FNFDriverInputBlocker
+    {
+        
+        private static bool Prefix()
+        {
+            WeaponSystem weapon = PlayerInput.Instance?.CurrentPlayerWeapon?.Weapon;
+            if (weapon == null) return true;
+
+            FNFManager fnf = weapon.GetComponent<FNFManager>();
+            if (fnf != null && fnf.seeker_active && !PlayerInput.Instance.IsExteriorMode)
+                return false;
+
+            return true;
         }
     }
 

--- a/FNF/FNFManager.cs
+++ b/FNF/FNFManager.cs
@@ -250,7 +250,7 @@ namespace M2BradleyExtended.FNF
 
         public void SetSeeker(bool enabled)
         {
-            if (enabled)
+            if (enabled && M2Ext.alternative_tracking_gate_controls.Value)
                 own_vehicle.Chassis.KillDriving(true, false, false);
 
             seeker_active = enabled;
@@ -268,6 +268,7 @@ namespace M2BradleyExtended.FNF
     {
         private static void Postfix()
         {
+            if(!M2Ext.alternative_tracking_gate_controls.Value) return;
             WeaponSystem weapon = PlayerInput.Instance?.CurrentPlayerWeapon?.Weapon;
             if (weapon == null) return;
 
@@ -296,6 +297,7 @@ namespace M2BradleyExtended.FNF
         
         private static bool Prefix()
         {
+            if (!M2Ext.alternative_tracking_gate_controls.Value) return true;
             WeaponSystem weapon = PlayerInput.Instance?.CurrentPlayerWeapon?.Weapon;
             if (weapon == null) return true;
 

--- a/FNF/FNFOptic.cs
+++ b/FNF/FNFOptic.cs
@@ -68,8 +68,15 @@ namespace M2BradleyExtended.FNF
 
             Vector2 local_positon = manual_gates.transform.localPosition;
             Vector2 size_delta = manual_gates.sizeDelta;
+            if (M2Ext.alternative_tracking_gate_controls.Value)
+            {
+                AlternativeHandleKeyboardInput();
+            }
+            else
+            {
+                HandleKeyboardInput();
 
-            HandleKeyboardInput();
+            }
             if (!manager.point_targeting && manager.target && !manager.target_locked) ResolveLock();
         }
 
@@ -85,18 +92,47 @@ namespace M2BradleyExtended.FNF
 
         private void HandleKeyboardInput()
         {
+            if (Input.GetKey(KeyCode.UpArrow))
+            {
+                UpdateTrackingGateDim(0f, 144f);
+            }
+
+            if (Input.GetKey(KeyCode.DownArrow))
+            {
+                UpdateTrackingGateDim(0f, -144f);
+            }
+
+            if (Input.GetKey(KeyCode.RightArrow))
+            {
+                UpdateTrackingGateDim(144f, 0f);
+            }
+
+            if (Input.GetKey(KeyCode.LeftArrow))
+            {
+                UpdateTrackingGateDim(-144f, 0f);
+            }
+        }
+
+        private void AlternativeHandleKeyboardInput()
+        {
             if (PlayerInput.Instance.IsExteriorMode) return;
             if (InputUtil.MainPlayer.GetButton("Movement Y Pos"))
+            {
                 UpdateTrackingGateDim(0f, 144f);
+            }
 
             if (InputUtil.MainPlayer.GetButton("Movement Y Neg"))
+            {
                 UpdateTrackingGateDim(0f, -144f);
-
+            }
             if (InputUtil.MainPlayer.GetButton("Movement X Pos"))
+            {
                 UpdateTrackingGateDim(144f, 0f);
-
+            }
             if (InputUtil.MainPlayer.GetButton("Movement X Neg"))
+            {
                 UpdateTrackingGateDim(-144f, 0f);
+            }
         }
         private void ResolveLock()
         {

--- a/FNF/FNFOptic.cs
+++ b/FNF/FNFOptic.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
+using GHPC.Player;
+using GHPC.Utility;
 
 namespace M2BradleyExtended.FNF
 {
@@ -83,27 +85,19 @@ namespace M2BradleyExtended.FNF
 
         private void HandleKeyboardInput()
         {
-            if (Input.GetKey(KeyCode.UpArrow))
-            {
+            if (PlayerInput.Instance.IsExteriorMode) return;
+            if (InputUtil.MainPlayer.GetButton("Movement Y Pos"))
                 UpdateTrackingGateDim(0f, 144f);
-            }
 
-            if (Input.GetKey(KeyCode.DownArrow))
-            {
+            if (InputUtil.MainPlayer.GetButton("Movement Y Neg"))
                 UpdateTrackingGateDim(0f, -144f);
-            }
 
-            if (Input.GetKey(KeyCode.RightArrow))
-            {
+            if (InputUtil.MainPlayer.GetButton("Movement X Pos"))
                 UpdateTrackingGateDim(144f, 0f);
-            }
 
-            if (Input.GetKey(KeyCode.LeftArrow))
-            {
+            if (InputUtil.MainPlayer.GetButton("Movement X Neg"))
                 UpdateTrackingGateDim(-144f, 0f);
-            }
         }
-
         private void ResolveLock()
         {
             float gate_x = gates.sizeDelta.x;

--- a/M2Ext.cs
+++ b/M2Ext.cs
@@ -39,6 +39,7 @@ namespace M2BradleyExtended
         static MelonPreferences_Entry<bool> has_citv;
         static MelonPreferences_Entry<bool> green_thermals;
         static MelonPreferences_Entry<bool> clear_thermals;
+        internal static MelonPreferences_Entry<bool> alternative_tracking_gate_controls;
 
         public static void Config(MelonPreferences_Category cfg) {
             m2_patch = cfg.CreateEntry<bool>("M2 Bradley Patch", true);
@@ -70,6 +71,9 @@ namespace M2BradleyExtended
 
             quickswap_bins = cfg.CreateEntry<bool>("Quick Refill Ammo Bins", false);
             quickswap_bins.Comment = "Reduces time to replenish autocannon ammo bins to 15 seconds";
+
+            alternative_tracking_gate_controls = cfg.CreateEntry<bool>("Alternative Tracking Gate Controls", false);
+            alternative_tracking_gate_controls.Comment = "Changes tracking gate controls to use vehicle steering keybinds; accelerate and brake replace up arrow and down arrow, steer right and steer left replace right arrow and left arrow.";
 
             //has_citv = cfg.CreateEntry<bool>("Has CITV", false);
             //has_citv.Comment = "Gives commander their own thermal optic; ";


### PR DESCRIPTION
Using arrow keys doesn't allow for keybind customization, slows down engagement times since you have to move one of your hands, and since I use my right hand as it is closer to the arrow keys, I can't turn my turret while looking for a lock. This patch would make use of WASD or the associated keybinds, and stops the vehicle when a) in gunner view and b) acquiring a lock, if neither condition is satisfied vehicle can move as usual.

Also, this mod presents an issue for controller players ATM since it requires 4 additional keybinds. This patch would change it to make use of existing keybinds instead.